### PR TITLE
fix: Server-side ownership checks and NaN% guard

### DIFF
--- a/src/app/(main)/treetest/results/[id]/_components/participants-tab.tsx
+++ b/src/app/(main)/treetest/results/[id]/_components/participants-tab.tsx
@@ -328,8 +328,14 @@ export function ParticipantsTab({ studyId, isOwner }: ParticipantsTabProps) {
                 { total: 0, successful: 0, direct: 0 }
               );
 
-              const successRate = Math.round((taskStats.successful / taskStats.total) * 100);
-              const directnessRate = Math.round((taskStats.direct / taskStats.total) * 100);
+              const successRate =
+                taskStats.total === 0
+                  ? 0
+                  : Math.round((taskStats.successful / taskStats.total) * 100);
+              const directnessRate =
+                taskStats.total === 0
+                  ? 0
+                  : Math.round((taskStats.direct / taskStats.total) * 100);
 
               return (
                 <TableRow

--- a/src/app/(main)/treetest/results/[id]/_components/participants-tab.tsx
+++ b/src/app/(main)/treetest/results/[id]/_components/participants-tab.tsx
@@ -333,9 +333,7 @@ export function ParticipantsTab({ studyId, isOwner }: ParticipantsTabProps) {
                   ? 0
                   : Math.round((taskStats.successful / taskStats.total) * 100);
               const directnessRate =
-                taskStats.total === 0
-                  ? 0
-                  : Math.round((taskStats.direct / taskStats.total) * 100);
+                taskStats.total === 0 ? 0 : Math.round((taskStats.direct / taskStats.total) * 100);
 
               return (
                 <TableRow

--- a/src/app/(main)/treetest/results/[id]/_components/participants-tab.tsx
+++ b/src/app/(main)/treetest/results/[id]/_components/participants-tab.tsx
@@ -330,10 +330,12 @@ export function ParticipantsTab({ studyId, isOwner }: ParticipantsTabProps) {
 
               const successRate =
                 taskStats.total === 0
-                  ? 0
+                  ? null
                   : Math.round((taskStats.successful / taskStats.total) * 100);
               const directnessRate =
-                taskStats.total === 0 ? 0 : Math.round((taskStats.direct / taskStats.total) * 100);
+                taskStats.total === 0
+                  ? null
+                  : Math.round((taskStats.direct / taskStats.total) * 100);
 
               return (
                 <TableRow
@@ -407,8 +409,8 @@ export function ParticipantsTab({ studyId, isOwner }: ParticipantsTabProps) {
                       "-"
                     )}
                   </TableCell>
-                  <TableCell>{successRate}%</TableCell>
-                  <TableCell>{directnessRate}%</TableCell>
+                  <TableCell>{successRate !== null ? `${successRate}%` : "-"}</TableCell>
+                  <TableCell>{directnessRate !== null ? `${directnessRate}%` : "-"}</TableCell>
                 </TableRow>
               );
             })}

--- a/src/lib/treetest/actions.ts
+++ b/src/lib/treetest/actions.ts
@@ -70,13 +70,15 @@ export async function updateStudyStatus(id: string, status: "draft" | "active" |
   }
 
   try {
-    await db
+    const result = await db
       .update(studies)
       .set({ status, updatedAt: new Date() })
       .where(and(eq(studies.id, id), eq(studies.userId, user.id)));
+    if (result.rowsAffected === 0) throw new Error("Forbidden");
 
     revalidatePath(`/treetest/setup/${id}`);
   } catch (error) {
+    if (error instanceof Error && error.message === "Forbidden") throw error;
     console.error("Failed to update study status:", error);
     throw new Error("Failed to update study status");
   }
@@ -89,9 +91,13 @@ export async function deleteStudy(id: string) {
   }
 
   try {
-    await db.delete(studies).where(and(eq(studies.id, id), eq(studies.userId, user.id)));
+    const result = await db
+      .delete(studies)
+      .where(and(eq(studies.id, id), eq(studies.userId, user.id)));
+    if (result.rowsAffected === 0) throw new Error("Forbidden");
     revalidatePath("/dashboard");
   } catch (error) {
+    if (error instanceof Error && error.message === "Forbidden") throw error;
     console.error("Failed to delete study:", error);
     throw new Error("Failed to delete study");
   }
@@ -258,6 +264,7 @@ export async function saveStudyData(id: string, data: StudyFormData) {
     revalidatePath(`/treetest/results/${id}`);
     return { success: true };
   } catch (error) {
+    if (error instanceof Error && error.message === "Forbidden") throw error;
     console.error("Failed to save study data:", error);
     throw new Error("Failed to save study data");
   }

--- a/src/lib/treetest/actions.ts
+++ b/src/lib/treetest/actions.ts
@@ -9,6 +9,13 @@ import { desc, and, ne, eq, sql } from "drizzle-orm";
 import { StudyFormData, TreeNode } from "@/lib/types/tree-test";
 import { getDefaultLanguage } from "@/lib/languages";
 
+class ForbiddenError extends Error {
+  constructor(message = "Forbidden") {
+    super(message);
+    this.name = "ForbiddenError";
+  }
+}
+
 const defaultLanguage = getDefaultLanguage();
 const defaultWelcomeMessage = defaultLanguage.messages.welcome;
 const defaultCompletionMessage = defaultLanguage.messages.completion;
@@ -74,11 +81,12 @@ export async function updateStudyStatus(id: string, status: "draft" | "active" |
       .update(studies)
       .set({ status, updatedAt: new Date() })
       .where(and(eq(studies.id, id), eq(studies.userId, user.id)));
-    if (result.rowsAffected === 0) throw new Error("Forbidden");
+    // rowsAffected === 0 means study not found or not owned — intentionally ambiguous
+    if (result.rowsAffected === 0) throw new ForbiddenError();
 
     revalidatePath(`/treetest/setup/${id}`);
   } catch (error) {
-    if (error instanceof Error && error.message === "Forbidden") throw error;
+    if (error instanceof ForbiddenError) throw error;
     console.error("Failed to update study status:", error);
     throw new Error("Failed to update study status");
   }
@@ -94,10 +102,11 @@ export async function deleteStudy(id: string) {
     const result = await db
       .delete(studies)
       .where(and(eq(studies.id, id), eq(studies.userId, user.id)));
-    if (result.rowsAffected === 0) throw new Error("Forbidden");
+    // rowsAffected === 0 means study not found or not owned — intentionally ambiguous
+    if (result.rowsAffected === 0) throw new ForbiddenError();
     revalidatePath("/dashboard");
   } catch (error) {
-    if (error instanceof Error && error.message === "Forbidden") throw error;
+    if (error instanceof ForbiddenError) throw error;
     console.error("Failed to delete study:", error);
     throw new Error("Failed to delete study");
   }
@@ -114,7 +123,7 @@ export async function saveStudyData(id: string, data: StudyFormData) {
         .from(studies)
         .where(eq(studies.id, id));
 
-      if (!study || study.userId !== user.id) throw new Error("Forbidden");
+      if (!study || study.userId !== user.id) throw new ForbiddenError();
 
       await tx
         .update(studies)
@@ -264,7 +273,7 @@ export async function saveStudyData(id: string, data: StudyFormData) {
     revalidatePath(`/treetest/results/${id}`);
     return { success: true };
   } catch (error) {
-    if (error instanceof Error && error.message === "Forbidden") throw error;
+    if (error instanceof ForbiddenError) throw error;
     console.error("Failed to save study data:", error);
     throw new Error("Failed to save study data");
   }
@@ -777,7 +786,7 @@ export async function recalculateStudyResults(studyId: string) {
       .from(treeConfigs)
       .innerJoin(studies, eq(studies.id, treeConfigs.studyId))
       .where(and(eq(treeConfigs.studyId, studyId), eq(studies.userId, user.id)));
-    if (configRow === undefined) throw new Error("Forbidden");
+    if (configRow === undefined) throw new ForbiddenError();
     if (!configRow.parsedTree) throw new Error("No tree config found");
 
     const parsedTree = JSON.parse(configRow.parsedTree) as TreeNode[];
@@ -814,11 +823,8 @@ export async function recalculateStudyResults(studyId: string) {
     revalidatePath(`/treetest/results/${studyId}`);
     return { success: true, updated };
   } catch (error) {
-    if (
-      error instanceof Error &&
-      (error.message === "Forbidden" || error.message === "No tree config found")
-    )
-      throw error;
+    if (error instanceof ForbiddenError) throw error;
+    if (error instanceof Error && error.message === "No tree config found") throw error;
     console.error("Failed to recalculate study results:", error);
     throw new Error("Failed to recalculate study results");
   }

--- a/src/lib/treetest/actions.ts
+++ b/src/lib/treetest/actions.ts
@@ -290,7 +290,7 @@ export async function loadStudyData(id: string) {
       .select()
       .from(studies)
       .where(and(eq(studies.id, id), eq(studies.userId, user.id)));
-    if (!study) throw new Error("Study not found");
+    if (!study) throw new ForbiddenError();
 
     const [config] = await db.select().from(treeConfigs).where(eq(treeConfigs.studyId, id));
 
@@ -345,7 +345,7 @@ export async function loadStudyData(id: string) {
       },
     } satisfies StudyFormData;
   } catch (error) {
-    if (error instanceof Error && error.message === "Study not found") throw error;
+    if (error instanceof ForbiddenError) throw error;
     console.error("Failed to load study data:", error);
     throw new Error("Failed to load study data");
   }
@@ -781,6 +781,10 @@ export async function recalculateStudyResults(studyId: string) {
   }
 
   try {
+    // Ownership + config fetched in a single query to avoid an extra Turso read.
+    // This conflates "not owner" with "no treeConfig row", but treeConfigs is
+    // always created atomically with the study in createStudy(), so the latter
+    // case cannot occur in practice. Will be revisited in a future overhaul.
     const [configRow] = await db
       .select({ parsedTree: treeConfigs.parsedTree })
       .from(treeConfigs)

--- a/src/lib/treetest/actions.ts
+++ b/src/lib/treetest/actions.ts
@@ -336,6 +336,7 @@ export async function loadStudyData(id: string) {
       },
     } satisfies StudyFormData;
   } catch (error) {
+    if (error instanceof Error && error.message === "Study not found") throw error;
     console.error("Failed to load study data:", error);
     throw new Error("Failed to load study data");
   }
@@ -771,14 +772,15 @@ export async function recalculateStudyResults(studyId: string) {
   }
 
   try {
-    const [result] = await db
+    const [configRow] = await db
       .select({ parsedTree: treeConfigs.parsedTree })
       .from(treeConfigs)
       .innerJoin(studies, eq(studies.id, treeConfigs.studyId))
       .where(and(eq(treeConfigs.studyId, studyId), eq(studies.userId, user.id)));
-    if (!result?.parsedTree) throw new Error("No tree config found");
+    if (configRow === undefined) throw new Error("Forbidden");
+    if (!configRow.parsedTree) throw new Error("No tree config found");
 
-    const parsedTree = JSON.parse(result.parsedTree) as TreeNode[];
+    const parsedTree = JSON.parse(configRow.parsedTree) as TreeNode[];
 
     const tasks = await db.select().from(treeTasks).where(eq(treeTasks.studyId, studyId));
 
@@ -812,6 +814,11 @@ export async function recalculateStudyResults(studyId: string) {
     revalidatePath(`/treetest/results/${studyId}`);
     return { success: true, updated };
   } catch (error) {
+    if (
+      error instanceof Error &&
+      (error.message === "Forbidden" || error.message === "No tree config found")
+    )
+      throw error;
     console.error("Failed to recalculate study results:", error);
     throw new Error("Failed to recalculate study results");
   }

--- a/src/lib/treetest/actions.ts
+++ b/src/lib/treetest/actions.ts
@@ -70,7 +70,10 @@ export async function updateStudyStatus(id: string, status: "draft" | "active" |
   }
 
   try {
-    await db.update(studies).set({ status, updatedAt: new Date() }).where(eq(studies.id, id));
+    await db
+      .update(studies)
+      .set({ status, updatedAt: new Date() })
+      .where(and(eq(studies.id, id), eq(studies.userId, user.id)));
 
     revalidatePath(`/treetest/setup/${id}`);
   } catch (error) {
@@ -86,7 +89,7 @@ export async function deleteStudy(id: string) {
   }
 
   try {
-    await db.delete(studies).where(eq(studies.id, id));
+    await db.delete(studies).where(and(eq(studies.id, id), eq(studies.userId, user.id)));
     revalidatePath("/dashboard");
   } catch (error) {
     console.error("Failed to delete study:", error);
@@ -101,9 +104,11 @@ export async function saveStudyData(id: string, data: StudyFormData) {
   try {
     await db.transaction(async (tx) => {
       const [study] = await tx
-        .select({ status: studies.status })
+        .select({ status: studies.status, userId: studies.userId })
         .from(studies)
         .where(eq(studies.id, id));
+
+      if (!study || study.userId !== user.id) throw new Error("Forbidden");
 
       await tx
         .update(studies)
@@ -265,7 +270,10 @@ export async function loadStudyData(id: string) {
   }
 
   try {
-    const [study] = await db.select().from(studies).where(eq(studies.id, id));
+    const [study] = await db
+      .select()
+      .from(studies)
+      .where(and(eq(studies.id, id), eq(studies.userId, user.id)));
     if (!study) throw new Error("Study not found");
 
     const [config] = await db.select().from(treeConfigs).where(eq(treeConfigs.studyId, id));
@@ -756,10 +764,14 @@ export async function recalculateStudyResults(studyId: string) {
   }
 
   try {
-    const [config] = await db.select().from(treeConfigs).where(eq(treeConfigs.studyId, studyId));
-    if (!config?.parsedTree) throw new Error("No tree config found");
+    const [result] = await db
+      .select({ parsedTree: treeConfigs.parsedTree })
+      .from(treeConfigs)
+      .innerJoin(studies, eq(studies.id, treeConfigs.studyId))
+      .where(and(eq(treeConfigs.studyId, studyId), eq(studies.userId, user.id)));
+    if (!result?.parsedTree) throw new Error("No tree config found");
 
-    const parsedTree = JSON.parse(config.parsedTree) as TreeNode[];
+    const parsedTree = JSON.parse(result.parsedTree) as TreeNode[];
 
     const tasks = await db.select().from(treeTasks).where(eq(treeTasks.studyId, studyId));
 


### PR DESCRIPTION
## Problem / Intent
Server actions (`saveStudyData`, `deleteStudy`, `updateStudyStatus`, `loadStudyData`, `recalculateStudyResults`) only verified authentication but not study ownership. A collaborator who knows the study ID could directly call these endpoints to modify or delete studies they don't own. Additionally, when a participant skipped every task, the success and directness rates displayed as `NaN%`.

## Approach
Ownership is verified by scoping existing DB queries to the authenticated user's ID — no extra database reads required. For mutations like `update` and `delete`, the `WHERE` clause includes `userId`; for reads that already fetch the study, the ownership check is added to the same query. The NaN fix guards against division by zero when computing rates.