### PR TITLE
Allow non-leaf nodes as correct answers

### DIFF
--- a/drizzle/0007_happy_cammi.sql
+++ b/drizzle/0007_happy_cammi.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `tree_configs` ADD `allow_non_leaf_answers` integer DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE `tree_task_results` ADD `selected_link` text;

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,1011 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "4b036c9c-a62f-48cd-ba08-0ad68a3e158d",
+  "prevId": "08be51f2-2ec3-401e-8e32-2d9201f406df",
+  "tables": {
+    "creem_processed_webhooks": {
+      "name": "creem_processed_webhooks",
+      "columns": {
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text(512)",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(STRFTIME('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_verification_codes": {
+      "name": "email_verification_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_unique": {
+          "name": "email_verification_codes_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_users_id_fk": {
+          "name": "email_verification_codes_user_id_users_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "participants": {
+      "name": "participants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "study_id": {
+          "name": "study_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(STRFTIME('%s', 'now') * 1000)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(STRFTIME('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "participants_session_id_unique": {
+          "name": "participants_session_id_unique",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": true
+        },
+        "idx_participants_study_id": {
+          "name": "idx_participants_study_id",
+          "columns": [
+            "study_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "participants_study_id_studies_id_fk": {
+          "name": "participants_study_id_studies_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "studies",
+          "columnsFrom": [
+            "study_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text(40)",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_password_reset_tokens_user_id": {
+          "name": "idx_password_reset_tokens_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text(255)",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "studies": {
+      "name": "studies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(STRFTIME('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(STRFTIME('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_studies_lookup": {
+          "name": "idx_studies_lookup",
+          "columns": [
+            "user_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "studies_user_id_users_id_fk": {
+          "name": "studies_user_id_users_id_fk",
+          "tableFrom": "studies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "study_collaborators": {
+      "name": "study_collaborators",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "study_id": {
+          "name": "study_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(STRFTIME('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_collaborations": {
+          "name": "idx_collaborations",
+          "columns": [
+            "study_id",
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "study_collaborators_study_id_studies_id_fk": {
+          "name": "study_collaborators_study_id_studies_id_fk",
+          "tableFrom": "study_collaborators",
+          "tableTo": "studies",
+          "columnsFrom": [
+            "study_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tree_configs": {
+      "name": "tree_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "study_id": {
+          "name": "study_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tree_structure": {
+          "name": "tree_structure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parsed_tree": {
+          "name": "parsed_tree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "welcome_message": {
+          "name": "welcome_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completion_message": {
+          "name": "completion_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_confidence_rating": {
+          "name": "require_confidence_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "randomize_tasks": {
+          "name": "randomize_tasks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "allow_non_leaf_answers": {
+          "name": "allow_non_leaf_answers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "instructions_text": {
+          "name": "instructions_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_test_text": {
+          "name": "start_test_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "find_it_here_text": {
+          "name": "find_it_here_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_task_text": {
+          "name": "start_task_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confidence_question_text": {
+          "name": "confidence_question_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strongly_agree_text": {
+          "name": "strongly_agree_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strongly_disagree_text": {
+          "name": "strongly_disagree_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_progress_text": {
+          "name": "task_progress_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skip_task_text": {
+          "name": "skip_task_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submit_continue_text": {
+          "name": "submit_continue_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_message_text": {
+          "name": "completed_message_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_button_text": {
+          "name": "next_button_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confidence_description_text": {
+          "name": "confidence_description_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tree_configs_study_id_studies_id_fk": {
+          "name": "tree_configs_study_id_studies_id_fk",
+          "tableFrom": "tree_configs",
+          "tableTo": "studies",
+          "columnsFrom": [
+            "study_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tree_task_results": {
+      "name": "tree_task_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "successful": {
+          "name": "successful",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "direct_path_taken": {
+          "name": "direct_path_taken",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completion_time_seconds": {
+          "name": "completion_time_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "confidence_rating": {
+          "name": "confidence_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path_taken": {
+          "name": "path_taken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selected_link": {
+          "name": "selected_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(STRFTIME('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_task_results_lookup": {
+          "name": "idx_task_results_lookup",
+          "columns": [
+            "participant_id",
+            "task_id"
+          ],
+          "isUnique": false
+        },
+        "idx_task_results_task_id": {
+          "name": "idx_task_results_task_id",
+          "columns": [
+            "task_id"
+          ],
+          "isUnique": false
+        },
+        "idx_task_results_time_stats": {
+          "name": "idx_task_results_time_stats",
+          "columns": [
+            "task_id",
+            "completion_time_seconds"
+          ],
+          "isUnique": false
+        },
+        "idx_task_results_confidence": {
+          "name": "idx_task_results_confidence",
+          "columns": [
+            "task_id",
+            "confidence_rating"
+          ],
+          "isUnique": false
+        },
+        "idx_task_results_path_analysis": {
+          "name": "idx_task_results_path_analysis",
+          "columns": [
+            "task_id",
+            "path_taken",
+            "successful",
+            "direct_path_taken"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tree_task_results_participant_id_participants_id_fk": {
+          "name": "tree_task_results_participant_id_participants_id_fk",
+          "tableFrom": "tree_task_results",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tree_task_results_task_id_tree_tasks_id_fk": {
+          "name": "tree_task_results_task_id_tree_tasks_id_fk",
+          "tableFrom": "tree_task_results",
+          "tableTo": "tree_tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tree_tasks": {
+      "name": "tree_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "study_id": {
+          "name": "study_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_index": {
+          "name": "task_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expected_answer": {
+          "name": "expected_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_time_seconds": {
+          "name": "max_time_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(STRFTIME('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(STRFTIME('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_tree_tasks_order": {
+          "name": "idx_tree_tasks_order",
+          "columns": [
+            "study_id",
+            "task_index"
+          ],
+          "isUnique": false
+        },
+        "unq_study_task_index": {
+          "name": "unq_study_task_index",
+          "columns": [
+            "study_id",
+            "task_index"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "tree_tasks_study_id_studies_id_fk": {
+          "name": "tree_tasks_study_id_studies_id_fk",
+          "tableFrom": "tree_tasks",
+          "tableTo": "studies",
+          "columnsFrom": [
+            "study_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text(21)",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "hashed_password": {
+          "name": "hashed_password",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creem_customer_id": {
+          "name": "creem_customer_id",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "study_limit": {
+          "name": "study_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(STRFTIME('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(STRFTIME('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "users_discord_id_unique": {
+          "name": "users_discord_id_unique",
+          "columns": [
+            "discord_id"
+          ],
+          "isUnique": true
+        },
+        "users_google_id_unique": {
+          "name": "users_google_id_unique",
+          "columns": [
+            "google_id"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1775132234379,
       "tag": "0006_conscious_tigra",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1780952653907,
+      "tag": "0007_happy_cammi",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(main)/dashboard/_components/dashboard-nav.tsx
+++ b/src/app/(main)/dashboard/_components/dashboard-nav.tsx
@@ -13,7 +13,7 @@ import { usePostHog } from "posthog-js/react";
 
 // Store the latest update date in a constant at the top of the file
 // This makes it easier to update in one place when new content is added
-const LATEST_UPDATE_DATE = "2026-04-24"; // Update this when new content is added
+const LATEST_UPDATE_DATE = "2026-06-10"; // Update this when new content is added
 
 const items = [
   {

--- a/src/app/(main)/dashboard/updates/updates-list.tsx
+++ b/src/app/(main)/dashboard/updates/updates-list.tsx
@@ -390,7 +390,7 @@ const updates: Update[] = [
   },
   {
     id: "29",
-    date: "2026-06-08",
+    date: "2026-06-10",
     title: "Allow Non-Leaf Nodes as Answers",
     description: "You can now set parent (non-leaf) nodes as correct answers for tree test tasks.",
     type: "feature",

--- a/src/app/(main)/dashboard/updates/updates-list.tsx
+++ b/src/app/(main)/dashboard/updates/updates-list.tsx
@@ -392,8 +392,7 @@ const updates: Update[] = [
     id: "29",
     date: "2026-06-08",
     title: "Allow Non-Leaf Nodes as Answers",
-    description:
-      "You can now set parent (non-leaf) nodes as correct answers for tree test tasks.",
+    description: "You can now set parent (non-leaf) nodes as correct answers for tree test tasks.",
     type: "feature",
     details: [
       "Correct answer paths can now point to a parent category, not just the final (leaf) item in your tree.",

--- a/src/app/(main)/dashboard/updates/updates-list.tsx
+++ b/src/app/(main)/dashboard/updates/updates-list.tsx
@@ -388,6 +388,18 @@ const updates: Update[] = [
       "If you've clicked Recalculate Stats on any study before, click it again to refresh your results.",
     ],
   },
+  {
+    id: "29",
+    date: "2026-06-08",
+    title: "Allow Non-Leaf Nodes as Answers",
+    description:
+      "You can now set parent (non-leaf) nodes as correct answers for tree test tasks.",
+    type: "feature",
+    details: [
+      "Correct answer paths can now point to a parent category, not just the final (leaf) item in your tree.",
+      "Helpful when the expected destination is a whole section rather than one specific page.",
+    ],
+  },
 ];
 
 export function UpdatesList() {

--- a/src/app/(main)/treetest/setup/[id]/_components/tasks-tab.tsx
+++ b/src/app/(main)/treetest/setup/[id]/_components/tasks-tab.tsx
@@ -174,9 +174,11 @@ export function TasksTab({ data, studyId, status, onChange }: TasksTabProps) {
         <Switch
           id="allow-non-leaf-answers"
           checked={data.tasks.allowNonLeafAnswers ?? false}
-          onCheckedChange={(checked) =>
-            onChange({ ...data, tasks: { ...data.tasks, allowNonLeafAnswers: checked } })
-          }
+          onCheckedChange={(checked) => {
+            onChange({ ...data, tasks: { ...data.tasks, allowNonLeafAnswers: checked } });
+            // Toggling changes which paths are valid, so stale results would mislead
+            setValidationResults({});
+          }}
         />
         <div className="flex flex-col gap-0.5">
           <Label htmlFor="allow-non-leaf-answers" className="cursor-pointer">

--- a/src/app/(main)/treetest/setup/[id]/_components/tasks-tab.tsx
+++ b/src/app/(main)/treetest/setup/[id]/_components/tasks-tab.tsx
@@ -236,8 +236,7 @@ export function TasksTab({ data, studyId, status, onChange }: TasksTabProps) {
               </Button>
             </div>
             <p className="text-xs text-muted-foreground">
-              All paths must start with{" "}
-              <code className="rounded bg-muted px-1 py-0.5">/</code>
+              All paths must start with <code className="rounded bg-muted px-1 py-0.5">/</code>
               {data.tasks.allowNonLeafAnswers
                 ? " and must exist in the tree (leaf or parent node, e.g., /home/products or /home)"
                 : " and must be a leaf (final destination) in the tree (e.g., /home/products)"}

--- a/src/app/(main)/treetest/setup/[id]/_components/tasks-tab.tsx
+++ b/src/app/(main)/treetest/setup/[id]/_components/tasks-tab.tsx
@@ -4,6 +4,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { StudyFormData, TreeNode } from "@/lib/types/tree-test";
+import { sanitizeTreeTestLink } from "@/lib/utils";
 import { PlusIcon, TrashIcon, CheckIcon } from "@/components/icons";
 import { ArrowUp } from "lucide-react";
 import {
@@ -34,13 +35,18 @@ export function TasksTab({ data, studyId, status, onChange }: TasksTabProps) {
     Record<number, { valid: string[]; invalid: string[]; missing: boolean } | null>
   >({});
 
-  // Recursive function to get all available paths from the tree
+  // Recursive function to get all available paths from the tree.
+  // Uses sanitizeTreeTestLink (same as tree-tab.tsx) so paths are byte-identical
+  // to what the participant flow produces.
   const getAllPaths = (nodes: TreeNode[], parentPath = ""): string[] => {
     let paths: string[] = [];
     nodes.forEach((node) => {
-      const currentPath = `${parentPath}/${node.name.toLowerCase().replace(/\s+/g, "-")}`;
+      const currentPath = `${parentPath}/${sanitizeTreeTestLink(node.name)}`;
       if (node.link) {
         paths.push(node.link);
+      } else if (data.tasks.allowNonLeafAnswers) {
+        // Non-leaf: generate the path the same way tree-tab.tsx does for leaves
+        paths.push(currentPath);
       }
       if (node.children) {
         paths = [...paths, ...getAllPaths(node.children, currentPath)];
@@ -87,15 +93,10 @@ export function TasksTab({ data, studyId, status, onChange }: TasksTabProps) {
     }
   };
 
-  // Recursive function to check if a path exists in the tree
-  const checkPathInTree = (nodes: TreeNode[], path: string): boolean => {
-    for (const node of nodes) {
-      if (node.link === path) return true;
-      if (node.children && node.children.length > 0) {
-        if (checkPathInTree(node.children, path)) return true;
-      }
-    }
-    return false;
+  // Check membership against the already-computed availablePaths set (includes
+  // non-leaf paths when allowNonLeafAnswers is on) so validation and picker agree.
+  const checkPathInTree = (_nodes: TreeNode[], path: string): boolean => {
+    return availablePaths.includes(path);
   };
 
   const validateAnswer = (index: number) => {
@@ -169,6 +170,23 @@ export function TasksTab({ data, studyId, status, onChange }: TasksTabProps) {
           Randomize task order for each participant
         </Label>
       </div>
+      <div className="flex items-center gap-3 rounded-lg border p-4">
+        <Switch
+          id="allow-non-leaf-answers"
+          checked={data.tasks.allowNonLeafAnswers ?? false}
+          onCheckedChange={(checked) =>
+            onChange({ ...data, tasks: { ...data.tasks, allowNonLeafAnswers: checked } })
+          }
+        />
+        <div className="flex flex-col gap-0.5">
+          <Label htmlFor="allow-non-leaf-answers" className="cursor-pointer">
+            Allow non-leaf (parent) nodes as answers
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            When on, parent category nodes can be set as correct answers for tasks.
+          </p>
+        </div>
+      </div>
       {data.tasks.items.map((task, index) => (
         <div key={index} className="relative space-y-4 rounded-lg border p-4">
           <div className="flex items-center justify-between">
@@ -212,8 +230,11 @@ export function TasksTab({ data, studyId, status, onChange }: TasksTabProps) {
               </Button>
             </div>
             <p className="text-xs text-muted-foreground">
-              All paths must start with <code className="rounded bg-muted px-1 py-0.5">/</code> and
-              must be a leaf (final destination) in the tree (e.g., /home/products)
+              All paths must start with{" "}
+              <code className="rounded bg-muted px-1 py-0.5">/</code>
+              {data.tasks.allowNonLeafAnswers
+                ? " and must exist in the tree (leaf or parent node, e.g., /home/products or /home)"
+                : " and must be a leaf (final destination) in the tree (e.g., /home/products)"}
             </p>
             <div className="flex flex-col gap-2 sm:flex-row sm:items-start">
               <Popover

--- a/src/app/(main)/treetest/setup/[id]/_components/tasks-tab.tsx
+++ b/src/app/(main)/treetest/setup/[id]/_components/tasks-tab.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import { CopyTasksDialog } from "./copy-tasks-dialog";
 import { SETUP_TOUR_STEP_IDS } from "@/lib/constants";
@@ -34,6 +34,12 @@ export function TasksTab({ data, studyId, status, onChange }: TasksTabProps) {
   const [validationResults, setValidationResults] = useState<
     Record<number, { valid: string[]; invalid: string[]; missing: boolean } | null>
   >({});
+
+  // Toggling allowNonLeafAnswers (here or from the tree tab's preview) changes which
+  // paths are valid, so stale validation badges would mislead
+  useEffect(() => {
+    setValidationResults({});
+  }, [data.tasks.allowNonLeafAnswers]);
 
   // Recursive function to get all available paths from the tree.
   // Uses sanitizeTreeTestLink (same as tree-tab.tsx) so paths are byte-identical
@@ -174,11 +180,9 @@ export function TasksTab({ data, studyId, status, onChange }: TasksTabProps) {
         <Switch
           id="allow-non-leaf-answers"
           checked={data.tasks.allowNonLeafAnswers ?? false}
-          onCheckedChange={(checked) => {
-            onChange({ ...data, tasks: { ...data.tasks, allowNonLeafAnswers: checked } });
-            // Toggling changes which paths are valid, so stale results would mislead
-            setValidationResults({});
-          }}
+          onCheckedChange={(checked) =>
+            onChange({ ...data, tasks: { ...data.tasks, allowNonLeafAnswers: checked } })
+          }
         />
         <div className="flex flex-col gap-0.5">
           <Label htmlFor="allow-non-leaf-answers" className="cursor-pointer">

--- a/src/app/(main)/treetest/setup/[id]/_components/tree-tab.tsx
+++ b/src/app/(main)/treetest/setup/[id]/_components/tree-tab.tsx
@@ -200,7 +200,13 @@ export function TreeTab({ data, onChange }: TreeTabProps) {
       {data.tree.parsed.length > 0 && (
         <div className="space-y-2">
           <Label>Interactive Tree Preview</Label>
-          <TreePreview nodes={data.tree.parsed} />
+          <TreePreview
+            nodes={data.tree.parsed}
+            allowNonLeafAnswers={data.tasks.allowNonLeafAnswers ?? false}
+            onAllowNonLeafAnswersChange={(checked) =>
+              onChange({ ...data, tasks: { ...data.tasks, allowNonLeafAnswers: checked } })
+            }
+          />
           <div className="flex justify-end">
             <TooltipProvider delayDuration={100}>
               <Tooltip>

--- a/src/components/tree-preview.tsx
+++ b/src/components/tree-preview.tsx
@@ -221,7 +221,7 @@ export function TreePreview({
                     "group flex w-full items-center rounded transition-colors duration-200",
                     nodeLink === selectedLink
                       ? "border border-green-700 bg-[#e6f3d8]"
-                      : "bg-gray-200 hover:bg-gray-300"
+                      : "bg-gray-200 [@media(hover:hover)]:hover:bg-gray-300"
                   )}
                 >
                   <button
@@ -236,7 +236,7 @@ export function TreePreview({
                           // Desktop (sm+): fade only while the button is revealed.
                           "block truncate text-gray-900 [mask-image:linear-gradient(to_right,black_70%,transparent_100%)]",
                           !(node.isExpanded || nodeLink === selectedLink) &&
-                            "sm:[mask-image:none] sm:group-hover:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)] sm:group-focus-within:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)]"
+                            "sm:[mask-image:none] sm:[@media(hover:hover)]:group-hover:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)] sm:group-focus-within:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)]"
                         )}
                       >
                         {node.name}
@@ -247,7 +247,7 @@ export function TreePreview({
                     className={cn(
                       "shrink-0 opacity-100 transition-opacity duration-150",
                       !(node.isExpanded || nodeLink === selectedLink) &&
-                        "sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
+                        "sm:opacity-0 sm:[@media(hover:hover)]:group-hover:opacity-100 sm:group-focus-within:opacity-100"
                     )}
                   >
                     <Button
@@ -256,8 +256,8 @@ export function TreePreview({
                       className={cn(
                         "text-xs",
                         nodeLink === selectedLink
-                          ? "bg-[#72FFA4] text-black hover:bg-[#00D9C2]"
-                          : "bg-gray-300 hover:bg-[#72FFA4] hover:text-black"
+                          ? "bg-[#72FFA4] text-black [@media(hover:hover)]:hover:bg-[#00D9C2]"
+                          : "bg-gray-300 [@media(hover:hover)]:hover:bg-[#72FFA4] [@media(hover:hover)]:hover:text-black"
                       )}
                       onClick={(e) => {
                         e.stopPropagation();
@@ -285,8 +285,8 @@ export function TreePreview({
                   onClick={() => toggleExpand(node, currentPath)}
                   className={`flex w-full items-center justify-between rounded px-3 py-2 text-sm transition-colors duration-200 ${
                     showParticipantView
-                      ? "bg-gray-200 hover:bg-gray-300"
-                      : "bg-gray-100 hover:bg-gray-200"
+                      ? "bg-gray-200 [@media(hover:hover)]:hover:bg-gray-300"
+                      : "bg-gray-100 [@media(hover:hover)]:hover:bg-gray-200"
                   }`}
                   aria-expanded={node.isExpanded}
                 >
@@ -315,14 +315,14 @@ export function TreePreview({
                 showParticipantView
                   ? selectedLink === node.link
                     ? "cursor-pointer border border-green-700 bg-[#e6f3d8]"
-                    : "cursor-pointer bg-gray-200 hover:bg-gray-300"
+                    : "cursor-pointer bg-gray-200 [@media(hover:hover)]:hover:bg-gray-300"
                   : "bg-gray-50"
               }`}
               onClick={() => handleLinkClick(node.link || "")}
             >
               <span className="text-gray-900">{node.name}</span>
               {showParticipantView && selectedLink === node.link ? (
-                <button className="rounded bg-[#72FFA4] px-2 py-1 text-xs text-black hover:bg-[#00D9C2]">
+                <button className="rounded bg-[#72FFA4] px-2 py-1 text-xs text-black [@media(hover:hover)]:hover:bg-[#00D9C2]">
                   I&apos;d find it here
                 </button>
               ) : (

--- a/src/components/tree-preview.tsx
+++ b/src/components/tree-preview.tsx
@@ -236,7 +236,7 @@ export function TreePreview({
                           // Desktop (sm+): fade only while the button is revealed.
                           "block truncate text-gray-900 [mask-image:linear-gradient(to_right,black_70%,transparent_100%)]",
                           !(node.isExpanded || nodeLink === selectedLink) &&
-                            "sm:[mask-image:none] sm:[@media(hover:hover)]:group-hover:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)] sm:group-focus-within:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)]"
+                            "sm:[mask-image:none] sm:group-focus-within:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)] sm:[@media(hover:hover)]:group-hover:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)]"
                         )}
                       >
                         {node.name}
@@ -247,7 +247,7 @@ export function TreePreview({
                     className={cn(
                       "shrink-0 opacity-100 transition-opacity duration-150",
                       !(node.isExpanded || nodeLink === selectedLink) &&
-                        "sm:opacity-0 sm:[@media(hover:hover)]:group-hover:opacity-100 sm:group-focus-within:opacity-100"
+                        "sm:opacity-0 sm:group-focus-within:opacity-100 sm:[@media(hover:hover)]:group-hover:opacity-100"
                     )}
                   >
                     <Button

--- a/src/components/tree-preview.tsx
+++ b/src/components/tree-preview.tsx
@@ -232,10 +232,11 @@ export function TreePreview({
                     <span className="relative min-w-0 flex-1 text-left">
                       <span
                         className={cn(
-                          "block truncate text-gray-900",
-                          node.isExpanded || nodeLink === selectedLink
-                            ? "[mask-image:linear-gradient(to_right,black_70%,transparent_100%)]"
-                            : "group-hover:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)] group-focus-within:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)]"
+                          // Mobile: button is always visible, so always fade.
+                          // Desktop (sm+): fade only while the button is revealed.
+                          "block truncate text-gray-900 [mask-image:linear-gradient(to_right,black_70%,transparent_100%)]",
+                          !(node.isExpanded || nodeLink === selectedLink) &&
+                            "sm:[mask-image:none] sm:group-hover:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)] sm:group-focus-within:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)]"
                         )}
                       >
                         {node.name}
@@ -244,10 +245,9 @@ export function TreePreview({
                   </button>
                   <div
                     className={cn(
-                      "shrink-0 transition-opacity duration-150",
-                      node.isExpanded || nodeLink === selectedLink
-                        ? "opacity-100"
-                        : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+                      "shrink-0 opacity-100 transition-opacity duration-150",
+                      !(node.isExpanded || nodeLink === selectedLink) &&
+                        "sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
                     )}
                   >
                     <Button

--- a/src/components/tree-preview.tsx
+++ b/src/components/tree-preview.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { TreeNode } from "@/lib/types/tree-test";
-import { cn } from "@/lib/utils";
+import { cn, sanitizeTreeTestLink } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 
 interface TreeNodeWithExpanded extends TreeNode {
@@ -14,9 +14,17 @@ interface TreeNodeWithExpanded extends TreeNode {
 interface TreePreviewProps {
   nodes: TreeNode[];
   className?: string;
+  /** Bound to the study's "Allow non-leaf nodes as answers" setting (tasks tab) */
+  allowNonLeafAnswers?: boolean;
+  onAllowNonLeafAnswersChange?: (checked: boolean) => void;
 }
 
-export function TreePreview({ nodes, className }: TreePreviewProps) {
+export function TreePreview({
+  nodes,
+  className,
+  allowNonLeafAnswers = false,
+  onAllowNonLeafAnswersChange,
+}: TreePreviewProps) {
   const [showParticipantView, setShowParticipantView] = useState(false);
   const [selectedLink, setSelectedLink] = useState<string>();
   // Initialize all nodes as expanded
@@ -185,6 +193,10 @@ export function TreePreview({ nodes, className }: TreePreviewProps) {
     }
   };
 
+  const handleSelectNonLeaf = (currentPath: TreeNodeWithExpanded[]) => {
+    setSelectedLink("/" + currentPath.map((n) => sanitizeTreeTestLink(n.name)).join("/"));
+  };
+
   const renderNodes = (
     nodes: TreeNodeWithExpanded[],
     parentPath: TreeNodeWithExpanded[] = [],
@@ -194,26 +206,98 @@ export function TreePreview({ nodes, className }: TreePreviewProps) {
       const currentPath = [...parentPath, node];
       const hasChildren = node.children && node.children.length > 0;
 
+      const nodeLink = "/" + currentPath.map((n) => sanitizeTreeTestLink(n.name)).join("/");
+      const showNonLeafSelect = showParticipantView && allowNonLeafAnswers;
+
       return (
         <div key={`${node.name}-${level}-${index}`} className={level > 0 ? "ml-4" : ""}>
           {hasChildren ? (
             <div className="mb-2">
-              <button
-                onClick={() => toggleExpand(node, currentPath)}
-                className={`flex w-full items-center justify-between rounded px-3 py-2 text-sm transition-colors duration-200 ${
-                  showParticipantView
-                    ? "bg-gray-200 hover:bg-gray-300"
-                    : "bg-gray-100 hover:bg-gray-200"
-                }`}
-                aria-expanded={node.isExpanded}
-              >
-                <span className="text-left text-gray-900">{node.name}</span>
-                {node.isExpanded ? (
-                  <ChevronDown className="h-4 w-4 text-gray-600" />
-                ) : (
-                  <ChevronRight className="h-4 w-4 text-gray-600" />
-                )}
-              </button>
+              {showNonLeafSelect ? (
+                // Mirrors the participant UI (tree-test.tsx): label toggle, then "Select"
+                // revealed on hover/focus or when expanded, then chevron flush right
+                <div
+                  className={cn(
+                    "group flex w-full items-center rounded transition-colors duration-200",
+                    nodeLink === selectedLink
+                      ? "border border-green-700 bg-[#e6f3d8]"
+                      : "bg-gray-200 hover:bg-gray-300"
+                  )}
+                >
+                  <button
+                    onClick={() => toggleExpand(node, currentPath)}
+                    className="flex min-w-0 flex-1 items-center px-3 py-2 text-sm"
+                    aria-expanded={node.isExpanded}
+                  >
+                    <span className="relative min-w-0 flex-1 text-left">
+                      <span
+                        className={cn(
+                          "block truncate text-gray-900",
+                          node.isExpanded || nodeLink === selectedLink
+                            ? "[mask-image:linear-gradient(to_right,black_70%,transparent_100%)]"
+                            : "group-hover:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)] group-focus-within:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)]"
+                        )}
+                      >
+                        {node.name}
+                      </span>
+                    </span>
+                  </button>
+                  <div
+                    className={cn(
+                      "shrink-0 transition-opacity duration-150",
+                      node.isExpanded || nodeLink === selectedLink
+                        ? "opacity-100"
+                        : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+                    )}
+                  >
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      className={cn(
+                        "text-xs",
+                        nodeLink === selectedLink
+                          ? "bg-[#72FFA4] text-black hover:bg-[#00D9C2]"
+                          : "bg-gray-300 hover:bg-[#72FFA4] hover:text-black"
+                      )}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleSelectNonLeaf(currentPath);
+                      }}
+                    >
+                      Select
+                    </Button>
+                  </div>
+                  <button
+                    onClick={() => toggleExpand(node, currentPath)}
+                    className="shrink-0 py-2 pl-2 pr-3"
+                    tabIndex={-1}
+                    aria-hidden="true"
+                  >
+                    {node.isExpanded ? (
+                      <ChevronDown className="h-4 w-4 text-gray-600" />
+                    ) : (
+                      <ChevronRight className="h-4 w-4 text-gray-600" />
+                    )}
+                  </button>
+                </div>
+              ) : (
+                <button
+                  onClick={() => toggleExpand(node, currentPath)}
+                  className={`flex w-full items-center justify-between rounded px-3 py-2 text-sm transition-colors duration-200 ${
+                    showParticipantView
+                      ? "bg-gray-200 hover:bg-gray-300"
+                      : "bg-gray-100 hover:bg-gray-200"
+                  }`}
+                  aria-expanded={node.isExpanded}
+                >
+                  <span className="text-left text-gray-900">{node.name}</span>
+                  {node.isExpanded ? (
+                    <ChevronDown className="h-4 w-4 text-gray-600" />
+                  ) : (
+                    <ChevronRight className="h-4 w-4 text-gray-600" />
+                  )}
+                </button>
+              )}
               <div
                 className={cn(
                   "grid transition-all duration-300 ease-in-out",
@@ -266,7 +350,7 @@ export function TreePreview({ nodes, className }: TreePreviewProps) {
 
   return (
     <div className={cn("space-y-4 rounded-lg border bg-white p-4", className)}>
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <Button variant="outline" size="sm" onClick={expandAll} className="text-xs">
             Expand All
@@ -275,7 +359,18 @@ export function TreePreview({ nodes, className }: TreePreviewProps) {
             Collapse All
           </Button>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+          {onAllowNonLeafAnswersChange && (
+            <label className="flex items-center gap-2 text-xs text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={allowNonLeafAnswers}
+                onChange={(e) => onAllowNonLeafAnswersChange(e.target.checked)}
+                className="rounded"
+              />
+              Allow non-leaf nodes as answers
+            </label>
+          )}
           <label className="flex items-center gap-2 text-xs text-muted-foreground">
             <input
               type="checkbox"

--- a/src/components/tree-test.tsx
+++ b/src/components/tree-test.tsx
@@ -180,11 +180,11 @@ const Navigation = ({
                     <span className="relative min-w-0 flex-1 text-left">
                       <span
                         className={cn(
-                          "block truncate",
-                          // Fade visible when expanded (touch) or group-hover/focus-within (desktop)
-                          item.isExpanded || nodeLink === selectedLink
-                            ? "[mask-image:linear-gradient(to_right,black_70%,transparent_100%)]"
-                            : "group-hover:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)] group-focus-within:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)]"
+                          // Mobile: button is always visible, so always fade.
+                          // Desktop (sm+): fade only while the button is revealed.
+                          "block truncate [mask-image:linear-gradient(to_right,black_70%,transparent_100%)]",
+                          !(item.isExpanded || nodeLink === selectedLink) &&
+                            "sm:[mask-image:none] sm:group-hover:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)] sm:group-focus-within:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)]"
                         )}
                       >
                         {item.name}
@@ -193,14 +193,14 @@ const Navigation = ({
                   </button>
 
                   {/* "Select as answer" button — sits before the chevron so the chevron stays
-                      flush right like every other row. Revealed on hover/focus (desktop) and
-                      when expanded or already selected (touch, since there's no hover). */}
+                      flush right like every other row. Always visible on mobile (focus-based
+                      reveal is unreliable on touch); on sm+ revealed on hover/focus or when
+                      expanded/selected. */}
                   <div
                     className={cn(
-                      "shrink-0 transition-opacity duration-150",
-                      item.isExpanded || nodeLink === selectedLink
-                        ? "opacity-100"
-                        : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+                      "shrink-0 opacity-100 transition-opacity duration-150",
+                      !(item.isExpanded || nodeLink === selectedLink) &&
+                        "sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
                     )}
                   >
                     <Button

--- a/src/components/tree-test.tsx
+++ b/src/components/tree-test.tsx
@@ -13,7 +13,7 @@ import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { storeTreeTaskResult } from "@/lib/treetest/actions";
 import { Item, ItemWithExpanded, TreeTestConfig } from "@/lib/types/tree-test";
-import { sanitizeTreeTestLink } from "@/lib/utils";
+import { cn, sanitizeTreeTestLink } from "@/lib/utils";
 import * as Sentry from "@sentry/react";
 import { ChevronDown, ChevronRight, CircleAlert } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -42,12 +42,21 @@ interface NavigationProps {
   onSelect: (link: string) => void;
   resetKey: number;
   setPathTaken: Dispatch<SetStateAction<string>>;
+  allowNonLeafAnswers: boolean;
   customText: {
     findItHere: string;
+    selectAsAnswer: string;
   };
 }
 
-const Navigation = ({ items, onSelect, resetKey, setPathTaken, customText }: NavigationProps) => {
+const Navigation = ({
+  items,
+  onSelect,
+  resetKey,
+  setPathTaken,
+  allowNonLeafAnswers,
+  customText,
+}: NavigationProps) => {
   const [treeState, setTreeState] = useState<ItemWithExpanded[]>([]);
   const [selectedLink, setSelectedLink] = useState<string>();
 
@@ -132,26 +141,104 @@ const Navigation = ({ items, onSelect, resetKey, setPathTaken, customText }: Nav
     setPathTaken((prev) => `${prev}/${sanitizeTreeTestLink(name)}`);
   };
 
+  const handleSelectNonLeaf = (currentPath: string[]) => {
+    const nodeLink = "/" + currentPath.map(sanitizeTreeTestLink).join("/");
+    // Use the dedupe-aware append so expand-then-select doesn't double-append the segment
+    setPathTaken((prev) => appendPath(prev, currentPath[currentPath.length - 1]));
+    onSelect(nodeLink);
+  };
+
   const renderItems = (items: ItemWithExpanded[], parentPath: string[] = []) => {
     return items.map((item) => {
       const currentPath = [...parentPath, item.name];
+      const nodeLink = "/" + currentPath.map(sanitizeTreeTestLink).join("/");
 
       return (
         <div key={item.name} className={`${parentPath.length ? "ml-4" : ""} mb-2`}>
           {item.children ? (
             <div>
-              <button
-                onClick={() => toggleExpand(currentPath)}
-                className="flex w-full items-center justify-between rounded bg-gray-200 px-3 py-2 text-sm transition-colors duration-200 hover:bg-gray-300"
-                aria-expanded={item.isExpanded}
-              >
-                <span>{item.name}</span>
-                {item.isExpanded ? (
-                  <ChevronDown className="h-4 w-4" />
-                ) : (
-                  <ChevronRight className="h-4 w-4" />
-                )}
-              </button>
+              {allowNonLeafAnswers ? (
+                // When non-leaf answers are enabled: split row into toggle + reveal button.
+                // The outer div is the visual container; toggle is a flex-1 button so the
+                // expand/collapse affordance keeps its full natural click area.
+                <div
+                  className={cn(
+                    "group flex w-full items-center rounded transition-colors duration-200",
+                    nodeLink === selectedLink
+                      ? "border border-green-700 bg-[#e6f3d8]"
+                      : "bg-gray-200 hover:bg-gray-300"
+                  )}
+                >
+                  {/* Toggle button — expands/collapses; takes all remaining space */}
+                  <button
+                    onClick={() => toggleExpand(currentPath)}
+                    className="flex min-w-0 flex-1 items-center gap-2 px-3 py-2 text-sm"
+                    aria-expanded={item.isExpanded}
+                  >
+                    {/* Label with gradient fade before the reveal button */}
+                    <span className="relative min-w-0 flex-1 text-left">
+                      <span
+                        className={cn(
+                          "block truncate",
+                          // Fade visible when expanded (touch) or group-hover/focus-within (desktop)
+                          item.isExpanded || nodeLink === selectedLink
+                            ? "[mask-image:linear-gradient(to_right,black_70%,transparent_100%)]"
+                            : "group-hover:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)] group-focus-within:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)]"
+                        )}
+                      >
+                        {item.name}
+                      </span>
+                    </span>
+                    {item.isExpanded ? (
+                      <ChevronDown className="h-4 w-4 shrink-0" />
+                    ) : (
+                      <ChevronRight className="h-4 w-4 shrink-0" />
+                    )}
+                  </button>
+
+                  {/* "Select as answer" button — revealed on hover/focus (desktop) and when
+                      expanded or already selected (touch, since there's no hover). */}
+                  <div
+                    className={cn(
+                      "shrink-0 pr-1 transition-opacity duration-150",
+                      item.isExpanded || nodeLink === selectedLink
+                        ? "opacity-100"
+                        : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+                    )}
+                  >
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      className={cn(
+                        "text-xs",
+                        nodeLink === selectedLink
+                          ? "bg-[#72FFA4] text-black hover:bg-[#00D9C2]"
+                          : "bg-gray-300 hover:bg-[#72FFA4] hover:text-black"
+                      )}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleSelectNonLeaf(currentPath);
+                      }}
+                    >
+                      {customText.selectAsAnswer}
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                // Default: single expand/collapse button, no answer selection
+                <button
+                  onClick={() => toggleExpand(currentPath)}
+                  className="flex w-full items-center justify-between rounded bg-gray-200 px-3 py-2 text-sm transition-colors duration-200 hover:bg-gray-300"
+                  aria-expanded={item.isExpanded}
+                >
+                  <span>{item.name}</span>
+                  {item.isExpanded ? (
+                    <ChevronDown className="h-4 w-4" />
+                  ) : (
+                    <ChevronRight className="h-4 w-4" />
+                  )}
+                </button>
+              )}
               <div
                 className={`grid transition-all duration-300 ease-in-out ${
                   item.isExpanded ? "mt-2 grid-rows-[1fr]" : "grid-rows-[0fr]"
@@ -276,6 +363,7 @@ export function TreeTestComponent({ config, initialTaskIndex = 0, onTaskChange }
           completionTimeSeconds: duration,
           confidenceRating: confidenceLevel ? parseInt(confidenceLevel) : undefined,
           pathTaken: pathTaken,
+          selectedLink: selectedLink,
           skipped: false,
         });
       } else {
@@ -321,6 +409,7 @@ export function TreeTestComponent({ config, initialTaskIndex = 0, onTaskChange }
         directPathTaken: !pathTaken || pathTaken === `/${rootLink}`, // true if user didn't touch the nav menu = no path taken (direct skip)
         completionTimeSeconds: duration,
         pathTaken: pathTaken !== `/${rootLink}` ? pathTaken : "",
+        selectedLink: null,
         skipped: true,
       });
     }
@@ -408,8 +497,10 @@ export function TreeTestComponent({ config, initialTaskIndex = 0, onTaskChange }
                 onSelect={handleSelection}
                 resetKey={resetKey}
                 setPathTaken={setPathTaken}
+                allowNonLeafAnswers={config.allowNonLeafAnswers}
                 customText={{
                   findItHere: config.customText.findItHere,
+                  selectAsAnswer: "Select",
                 }}
               />
             )}

--- a/src/components/tree-test.tsx
+++ b/src/components/tree-test.tsx
@@ -173,7 +173,7 @@ const Navigation = ({
                   {/* Toggle button — expands/collapses; takes all remaining space */}
                   <button
                     onClick={() => toggleExpand(currentPath)}
-                    className="flex min-w-0 flex-1 items-center gap-2 px-3 py-2 text-sm"
+                    className="flex min-w-0 flex-1 items-center px-3 py-2 text-sm"
                     aria-expanded={item.isExpanded}
                   >
                     {/* Label with gradient fade before the reveal button */}
@@ -190,18 +190,14 @@ const Navigation = ({
                         {item.name}
                       </span>
                     </span>
-                    {item.isExpanded ? (
-                      <ChevronDown className="h-4 w-4 shrink-0" />
-                    ) : (
-                      <ChevronRight className="h-4 w-4 shrink-0" />
-                    )}
                   </button>
 
-                  {/* "Select as answer" button — revealed on hover/focus (desktop) and when
-                      expanded or already selected (touch, since there's no hover). */}
+                  {/* "Select as answer" button — sits before the chevron so the chevron stays
+                      flush right like every other row. Revealed on hover/focus (desktop) and
+                      when expanded or already selected (touch, since there's no hover). */}
                   <div
                     className={cn(
-                      "shrink-0 pr-1 transition-opacity duration-150",
+                      "shrink-0 transition-opacity duration-150",
                       item.isExpanded || nodeLink === selectedLink
                         ? "opacity-100"
                         : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
@@ -224,6 +220,21 @@ const Navigation = ({
                       {customText.selectAsAnswer}
                     </Button>
                   </div>
+
+                  {/* Chevron toggle — duplicate convenience target; the label button is the
+                      accessible one, so hide this from keyboard and screen readers */}
+                  <button
+                    onClick={() => toggleExpand(currentPath)}
+                    className="shrink-0 py-2 pl-2 pr-3"
+                    tabIndex={-1}
+                    aria-hidden="true"
+                  >
+                    {item.isExpanded ? (
+                      <ChevronDown className="h-4 w-4" />
+                    ) : (
+                      <ChevronRight className="h-4 w-4" />
+                    )}
+                  </button>
                 </div>
               ) : (
                 // Default: single expand/collapse button, no answer selection

--- a/src/components/tree-test.tsx
+++ b/src/components/tree-test.tsx
@@ -167,7 +167,7 @@ const Navigation = ({
                     "group flex w-full items-center rounded transition-colors duration-200",
                     nodeLink === selectedLink
                       ? "border border-green-700 bg-[#e6f3d8]"
-                      : "bg-gray-200 hover:bg-gray-300"
+                      : "bg-gray-200 [@media(hover:hover)]:hover:bg-gray-300"
                   )}
                 >
                   {/* Toggle button — expands/collapses; takes all remaining space */}
@@ -184,7 +184,7 @@ const Navigation = ({
                           // Desktop (sm+): fade only while the button is revealed.
                           "block truncate [mask-image:linear-gradient(to_right,black_70%,transparent_100%)]",
                           !(item.isExpanded || nodeLink === selectedLink) &&
-                            "sm:[mask-image:none] sm:group-hover:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)] sm:group-focus-within:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)]"
+                            "sm:[mask-image:none] sm:[@media(hover:hover)]:group-hover:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)] sm:group-focus-within:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)]"
                         )}
                       >
                         {item.name}
@@ -200,7 +200,7 @@ const Navigation = ({
                     className={cn(
                       "shrink-0 opacity-100 transition-opacity duration-150",
                       !(item.isExpanded || nodeLink === selectedLink) &&
-                        "sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
+                        "sm:opacity-0 sm:[@media(hover:hover)]:group-hover:opacity-100 sm:group-focus-within:opacity-100"
                     )}
                   >
                     <Button
@@ -209,8 +209,8 @@ const Navigation = ({
                       className={cn(
                         "text-xs",
                         nodeLink === selectedLink
-                          ? "bg-[#72FFA4] text-black hover:bg-[#00D9C2]"
-                          : "bg-gray-300 hover:bg-[#72FFA4] hover:text-black"
+                          ? "bg-[#72FFA4] text-black [@media(hover:hover)]:hover:bg-[#00D9C2]"
+                          : "bg-gray-300 [@media(hover:hover)]:hover:bg-[#72FFA4] [@media(hover:hover)]:hover:text-black"
                       )}
                       onClick={(e) => {
                         e.stopPropagation();
@@ -240,7 +240,7 @@ const Navigation = ({
                 // Default: single expand/collapse button, no answer selection
                 <button
                   onClick={() => toggleExpand(currentPath)}
-                  className="flex w-full items-center justify-between rounded bg-gray-200 px-3 py-2 text-sm transition-colors duration-200 hover:bg-gray-300"
+                  className="flex w-full items-center justify-between rounded bg-gray-200 px-3 py-2 text-sm transition-colors duration-200 [@media(hover:hover)]:hover:bg-gray-300"
                   aria-expanded={item.isExpanded}
                 >
                   <span>{item.name}</span>
@@ -264,7 +264,7 @@ const Navigation = ({
               className={`my-1 flex items-center justify-between rounded p-2 transition-colors duration-200 ${
                 item.link === selectedLink
                   ? "border border-green-700 bg-[#e6f3d8]"
-                  : "bg-gray-200 hover:bg-gray-300"
+                  : "bg-gray-200 [@media(hover:hover)]:hover:bg-gray-300"
               }`}
               onClick={() => handleLinkClick(item.link ?? "", item.name)}
             >
@@ -273,7 +273,7 @@ const Navigation = ({
                 <Button
                   variant="secondary"
                   size="sm"
-                  className="bg-[#72FFA4] text-black hover:bg-[#00D9C2]"
+                  className="bg-[#72FFA4] text-black [@media(hover:hover)]:hover:bg-[#00D9C2]"
                   onClick={(e) => {
                     e.stopPropagation();
                     onSelect(item.link ?? "");

--- a/src/components/tree-test.tsx
+++ b/src/components/tree-test.tsx
@@ -184,7 +184,7 @@ const Navigation = ({
                           // Desktop (sm+): fade only while the button is revealed.
                           "block truncate [mask-image:linear-gradient(to_right,black_70%,transparent_100%)]",
                           !(item.isExpanded || nodeLink === selectedLink) &&
-                            "sm:[mask-image:none] sm:[@media(hover:hover)]:group-hover:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)] sm:group-focus-within:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)]"
+                            "sm:[mask-image:none] sm:group-focus-within:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)] sm:[@media(hover:hover)]:group-hover:[mask-image:linear-gradient(to_right,black_70%,transparent_100%)]"
                         )}
                       >
                         {item.name}
@@ -200,7 +200,7 @@ const Navigation = ({
                     className={cn(
                       "shrink-0 opacity-100 transition-opacity duration-150",
                       !(item.isExpanded || nodeLink === selectedLink) &&
-                        "sm:opacity-0 sm:[@media(hover:hover)]:group-hover:opacity-100 sm:group-focus-within:opacity-100"
+                        "sm:opacity-0 sm:group-focus-within:opacity-100 sm:[@media(hover:hover)]:group-hover:opacity-100"
                     )}
                   >
                     <Button

--- a/src/components/tree-test.tsx
+++ b/src/components/tree-test.tsx
@@ -143,6 +143,7 @@ const Navigation = ({
 
   const handleSelectNonLeaf = (currentPath: string[]) => {
     const nodeLink = "/" + currentPath.map(sanitizeTreeTestLink).join("/");
+    setSelectedLink(nodeLink);
     // Use the dedupe-aware append so expand-then-select doesn't double-append the segment
     setPathTaken((prev) => appendPath(prev, currentPath[currentPath.length - 1]));
     onSelect(nodeLink);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -121,6 +121,9 @@ export const treeConfigs = sqliteTable("tree_configs", {
     .notNull()
     .default(true),
   randomizeTasks: integer("randomize_tasks", { mode: "boolean" }).notNull().default(false),
+  allowNonLeafAnswers: integer("allow_non_leaf_answers", { mode: "boolean" })
+    .notNull()
+    .default(false),
   // Customizable text fields
   instructionsText: text("instructions_text"),
   startTestText: text("start_test_text"),
@@ -200,6 +203,7 @@ export const treeTaskResults = sqliteTable(
     completionTimeSeconds: integer("completion_time_seconds").notNull(),
     confidenceRating: integer("confidence_rating"),
     pathTaken: text("path_taken").notNull(),
+    selectedLink: text("selected_link"),
     skipped: integer("skipped", { mode: "boolean" }).notNull().default(false),
     createdAt: integer("created_at", { mode: "timestamp" })
       .notNull()

--- a/src/lib/languages.ts
+++ b/src/lib/languages.ts
@@ -313,7 +313,7 @@ Grazie per il Suo interesse a partecipare.`,
       nextButton: "Prossimo",
       confidenceDescription: "Selezioni un valore da 1 a 7",
     },
-  }
+  },
 ];
 
 export function getLanguagePreset(code: string): TreeTestTranslation {

--- a/src/lib/treetest/actions.ts
+++ b/src/lib/treetest/actions.ts
@@ -302,8 +302,10 @@ export async function loadStudyData(id: string) {
   }
 
   try {
-    const [study] = await db.select().from(studies).where(eq(studies.id, id));
-    // .where(and(eq(studies.id, id), eq(studies.userId, user.id)));
+    const [study] = await db
+      .select()
+      .from(studies)
+      .where(and(eq(studies.id, id), eq(studies.userId, user.id)));
     if (!study) throw new ForbiddenError();
 
     const [config] = await db.select().from(treeConfigs).where(eq(treeConfigs.studyId, id));
@@ -868,8 +870,7 @@ export async function recalculateStudyResults(studyId: string) {
       .select({ parsedTree: treeConfigs.parsedTree })
       .from(treeConfigs)
       .innerJoin(studies, eq(studies.id, treeConfigs.studyId))
-      .where(eq(treeConfigs.studyId, studyId));
-    // .where(and(eq(treeConfigs.studyId, studyId), eq(studies.userId, user.id)));
+      .where(and(eq(treeConfigs.studyId, studyId), eq(studies.userId, user.id)));
     if (configRow === undefined) throw new ForbiddenError();
     if (!configRow.parsedTree) throw new Error("No tree config found");
 

--- a/src/lib/treetest/actions.ts
+++ b/src/lib/treetest/actions.ts
@@ -158,6 +158,7 @@ export async function saveStudyData(id: string, data: StudyFormData) {
             welcomeMessage: data.messages.welcome,
             completionMessage: data.messages.completion,
             randomizeTasks: data.tasks.randomizeTasks ?? false,
+            allowNonLeafAnswers: data.tasks.allowNonLeafAnswers ?? false,
             instructionsText: data.customText.instructions,
             startTestText: data.customText.startTest,
             findItHereText: data.customText.findItHere,
@@ -182,6 +183,7 @@ export async function saveStudyData(id: string, data: StudyFormData) {
           welcomeMessage: data.messages.welcome,
           completionMessage: data.messages.completion,
           randomizeTasks: data.tasks.randomizeTasks ?? false,
+          allowNonLeafAnswers: data.tasks.allowNonLeafAnswers ?? false,
           instructionsText: data.customText.instructions,
           startTestText: data.customText.startTest,
           findItHereText: data.customText.findItHere,
@@ -266,7 +268,8 @@ export async function saveStudyData(id: string, data: StudyFormData) {
 
               await Promise.all(
                 taskResults.map((result) => {
-                  const actualPath = resolveSelectedLink(sortedLinks, result.pathTaken);
+                  const actualPath =
+                    result.selectedLink ?? resolveSelectedLink(sortedLinks, result.pathTaken);
 
                   return tx
                     .update(treeTaskResults)
@@ -299,10 +302,8 @@ export async function loadStudyData(id: string) {
   }
 
   try {
-    const [study] = await db
-      .select()
-      .from(studies)
-      .where(and(eq(studies.id, id), eq(studies.userId, user.id)));
+    const [study] = await db.select().from(studies).where(eq(studies.id, id));
+    // .where(and(eq(studies.id, id), eq(studies.userId, user.id)));
     if (!study) throw new ForbiddenError();
 
     const [config] = await db.select().from(treeConfigs).where(eq(treeConfigs.studyId, id));
@@ -329,6 +330,7 @@ export async function loadStudyData(id: string) {
           answer: task.expectedAnswer,
         })),
         randomizeTasks: config?.randomizeTasks ?? false,
+        allowNonLeafAnswers: config?.allowNonLeafAnswers ?? false,
       },
       messages: {
         welcome: config?.welcomeMessage || "",
@@ -497,6 +499,7 @@ export async function loadTestConfig(id: string, preview: boolean = false, parti
         treeStructure: treeConfigs.parsedTree,
         requireConfidenceRating: treeConfigs.requireConfidenceRating,
         randomizeTasks: treeConfigs.randomizeTasks,
+        allowNonLeafAnswers: treeConfigs.allowNonLeafAnswers,
         instructionsText: treeConfigs.instructionsText,
         startTestText: treeConfigs.startTestText,
         findItHereText: treeConfigs.findItHereText,
@@ -559,6 +562,7 @@ export async function loadTestConfig(id: string, preview: boolean = false, parti
       })),
       requireConfidenceRating: config.requireConfidenceRating,
       randomizeTasks: config.randomizeTasks,
+      allowNonLeafAnswers: config.allowNonLeafAnswers ?? false,
       preview,
       participantId,
       studyId: id,
@@ -600,6 +604,7 @@ export async function storeTreeTaskResult(
     completionTimeSeconds: number;
     confidenceRating?: number;
     pathTaken: string;
+    selectedLink?: string | null;
     skipped: boolean;
   }
 ) {
@@ -613,6 +618,7 @@ export async function storeTreeTaskResult(
       completionTimeSeconds: result.completionTimeSeconds,
       confidenceRating: result.confidenceRating,
       pathTaken: result.pathTaken,
+      selectedLink: result.selectedLink ?? null,
       skipped: result.skipped,
     });
 
@@ -862,7 +868,8 @@ export async function recalculateStudyResults(studyId: string) {
       .select({ parsedTree: treeConfigs.parsedTree })
       .from(treeConfigs)
       .innerJoin(studies, eq(studies.id, treeConfigs.studyId))
-      .where(and(eq(treeConfigs.studyId, studyId), eq(studies.userId, user.id)));
+      .where(eq(treeConfigs.studyId, studyId));
+    // .where(and(eq(treeConfigs.studyId, studyId), eq(studies.userId, user.id)));
     if (configRow === undefined) throw new ForbiddenError();
     if (!configRow.parsedTree) throw new Error("No tree config found");
 
@@ -888,7 +895,8 @@ export async function recalculateStudyResults(studyId: string) {
       for (const result of results) {
         if (result.skipped) continue;
 
-        const actualPath = resolveSelectedLink(sortedLinks, result.pathTaken);
+        const actualPath =
+          result.selectedLink ?? resolveSelectedLink(sortedLinks, result.pathTaken);
         const successful = actualPath ? correctAnswers.includes(actualPath) : false;
 
         if (result.successful !== successful) {

--- a/src/lib/treetest/results-actions.ts
+++ b/src/lib/treetest/results-actions.ts
@@ -383,10 +383,15 @@ export async function getTasksStats(studyId: string): Promise<TaskStats[]> {
         const expectedAnswers = task.expectedAnswer.split(",").map((answer) => answer.trim());
 
         const expectedParentPaths = expectedAnswers.map((answer) => {
+          // If the answer is itself a top-level parent path (e.g. "/settings"), keep it as-is
+          // so it isn't re-derived to a shorter ancestor and mislabeled in the table.
+          // For deeper answers (e.g. "/settings/general"), derive the first-level parent.
           const expectedParts = answer.split("/").filter(Boolean);
-          return hasOnlyHomeRoot && expectedParts.length > 1
-            ? `/${homeRoot}/${expectedParts[1]}`
-            : `/${expectedParts[0]}`;
+          if (hasOnlyHomeRoot && expectedParts.length > 1) {
+            // Under a single home root, the "first-level parent" is the second segment
+            return `/${homeRoot}/${expectedParts[1]}`;
+          }
+          return `/${expectedParts[0]}`;
         });
 
         // For each possible parent name, check if it appears in the path

--- a/src/lib/types/tree-test.ts
+++ b/src/lib/types/tree-test.ts
@@ -14,6 +14,7 @@ export interface StudyFormData {
       answer: string;
     }>;
     randomizeTasks?: boolean;
+    allowNonLeafAnswers?: boolean;
   };
   messages: {
     welcome: string;
@@ -60,6 +61,7 @@ export interface TreeTestConfig {
   }[];
   requireConfidenceRating: boolean;
   randomizeTasks: boolean;
+  allowNonLeafAnswers: boolean;
   preview: boolean;
   participantId?: string;
   studyId: string;


### PR DESCRIPTION
## Problem / Intent

Tree tests currently only allow leaf (final-destination) nodes as correct answers. This prevents study owners from setting a parent category as the intended destination — a valid scenario when the goal is to reach a section rather than a specific page.

## Approach

The feature is gated by a per-study `allowNonLeafAnswers` toggle (mirroring `randomizeTasks`) so existing studies are entirely unaffected when off.

On the participant side, parent rows gain a "Select" button that reveals on hover/focus (desktop) or when the node is expanded (touch), with a gradient text-fade so long labels never collide with the button. The default click on a parent still toggles expand/collapse.

A `selected_link` column is added to `tree_task_results` and written at submission time (for both leaf and non-leaf answers). Scoring and Recalculate Stats now compare against this stored value directly, eliminating the resolver heuristic for any new result. Legacy rows (NULL) continue using the existing resolver unchanged.

A secondary fix lands in passing: the setup answer picker was computing non-leaf paths with a different sanitizer than the one `tree-tab.tsx` uses for leaf links (`sanitizeTreeTestLink`). This would have caused byte mismatches between owner-saved answers and participant selections — now both sides use the same function.