### PR TITLE
fix(treetest): make parent-node Select button translatable

### DIFF
--- a/drizzle/0008_peaceful_apocalypse.sql
+++ b/drizzle/0008_peaceful_apocalypse.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `tree_configs` ADD `select_as_answer_text` text;

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1018 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "611289a5-9759-46c2-b770-ecb9b0b4e203",
+  "prevId": "4b036c9c-a62f-48cd-ba08-0ad68a3e158d",
+  "tables": {
+    "creem_processed_webhooks": {
+      "name": "creem_processed_webhooks",
+      "columns": {
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text(512)",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(STRFTIME('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_verification_codes": {
+      "name": "email_verification_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_unique": {
+          "name": "email_verification_codes_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_users_id_fk": {
+          "name": "email_verification_codes_user_id_users_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "participants": {
+      "name": "participants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "study_id": {
+          "name": "study_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(STRFTIME('%s', 'now') * 1000)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(STRFTIME('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "participants_session_id_unique": {
+          "name": "participants_session_id_unique",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": true
+        },
+        "idx_participants_study_id": {
+          "name": "idx_participants_study_id",
+          "columns": [
+            "study_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "participants_study_id_studies_id_fk": {
+          "name": "participants_study_id_studies_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "studies",
+          "columnsFrom": [
+            "study_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text(40)",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_password_reset_tokens_user_id": {
+          "name": "idx_password_reset_tokens_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text(255)",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "studies": {
+      "name": "studies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(STRFTIME('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(STRFTIME('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_studies_lookup": {
+          "name": "idx_studies_lookup",
+          "columns": [
+            "user_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "studies_user_id_users_id_fk": {
+          "name": "studies_user_id_users_id_fk",
+          "tableFrom": "studies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "study_collaborators": {
+      "name": "study_collaborators",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "study_id": {
+          "name": "study_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(STRFTIME('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_collaborations": {
+          "name": "idx_collaborations",
+          "columns": [
+            "study_id",
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "study_collaborators_study_id_studies_id_fk": {
+          "name": "study_collaborators_study_id_studies_id_fk",
+          "tableFrom": "study_collaborators",
+          "tableTo": "studies",
+          "columnsFrom": [
+            "study_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tree_configs": {
+      "name": "tree_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "study_id": {
+          "name": "study_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tree_structure": {
+          "name": "tree_structure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parsed_tree": {
+          "name": "parsed_tree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "welcome_message": {
+          "name": "welcome_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completion_message": {
+          "name": "completion_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_confidence_rating": {
+          "name": "require_confidence_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "randomize_tasks": {
+          "name": "randomize_tasks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "allow_non_leaf_answers": {
+          "name": "allow_non_leaf_answers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "instructions_text": {
+          "name": "instructions_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_test_text": {
+          "name": "start_test_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "find_it_here_text": {
+          "name": "find_it_here_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "select_as_answer_text": {
+          "name": "select_as_answer_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_task_text": {
+          "name": "start_task_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confidence_question_text": {
+          "name": "confidence_question_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strongly_agree_text": {
+          "name": "strongly_agree_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strongly_disagree_text": {
+          "name": "strongly_disagree_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_progress_text": {
+          "name": "task_progress_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skip_task_text": {
+          "name": "skip_task_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submit_continue_text": {
+          "name": "submit_continue_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_message_text": {
+          "name": "completed_message_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_button_text": {
+          "name": "next_button_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confidence_description_text": {
+          "name": "confidence_description_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tree_configs_study_id_studies_id_fk": {
+          "name": "tree_configs_study_id_studies_id_fk",
+          "tableFrom": "tree_configs",
+          "tableTo": "studies",
+          "columnsFrom": [
+            "study_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tree_task_results": {
+      "name": "tree_task_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "successful": {
+          "name": "successful",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "direct_path_taken": {
+          "name": "direct_path_taken",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completion_time_seconds": {
+          "name": "completion_time_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "confidence_rating": {
+          "name": "confidence_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path_taken": {
+          "name": "path_taken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selected_link": {
+          "name": "selected_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(STRFTIME('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_task_results_lookup": {
+          "name": "idx_task_results_lookup",
+          "columns": [
+            "participant_id",
+            "task_id"
+          ],
+          "isUnique": false
+        },
+        "idx_task_results_task_id": {
+          "name": "idx_task_results_task_id",
+          "columns": [
+            "task_id"
+          ],
+          "isUnique": false
+        },
+        "idx_task_results_time_stats": {
+          "name": "idx_task_results_time_stats",
+          "columns": [
+            "task_id",
+            "completion_time_seconds"
+          ],
+          "isUnique": false
+        },
+        "idx_task_results_confidence": {
+          "name": "idx_task_results_confidence",
+          "columns": [
+            "task_id",
+            "confidence_rating"
+          ],
+          "isUnique": false
+        },
+        "idx_task_results_path_analysis": {
+          "name": "idx_task_results_path_analysis",
+          "columns": [
+            "task_id",
+            "path_taken",
+            "successful",
+            "direct_path_taken"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tree_task_results_participant_id_participants_id_fk": {
+          "name": "tree_task_results_participant_id_participants_id_fk",
+          "tableFrom": "tree_task_results",
+          "tableTo": "participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tree_task_results_task_id_tree_tasks_id_fk": {
+          "name": "tree_task_results_task_id_tree_tasks_id_fk",
+          "tableFrom": "tree_task_results",
+          "tableTo": "tree_tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tree_tasks": {
+      "name": "tree_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "study_id": {
+          "name": "study_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_index": {
+          "name": "task_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expected_answer": {
+          "name": "expected_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_time_seconds": {
+          "name": "max_time_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(STRFTIME('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(STRFTIME('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_tree_tasks_order": {
+          "name": "idx_tree_tasks_order",
+          "columns": [
+            "study_id",
+            "task_index"
+          ],
+          "isUnique": false
+        },
+        "unq_study_task_index": {
+          "name": "unq_study_task_index",
+          "columns": [
+            "study_id",
+            "task_index"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "tree_tasks_study_id_studies_id_fk": {
+          "name": "tree_tasks_study_id_studies_id_fk",
+          "tableFrom": "tree_tasks",
+          "tableTo": "studies",
+          "columnsFrom": [
+            "study_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text(21)",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "hashed_password": {
+          "name": "hashed_password",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creem_customer_id": {
+          "name": "creem_customer_id",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "study_limit": {
+          "name": "study_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(STRFTIME('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(STRFTIME('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "users_discord_id_unique": {
+          "name": "users_discord_id_unique",
+          "columns": [
+            "discord_id"
+          ],
+          "isUnique": true
+        },
+        "users_google_id_unique": {
+          "name": "users_google_id_unique",
+          "columns": [
+            "google_id"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1780952653907,
       "tag": "0007_happy_cammi",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1784055575439,
+      "tag": "0008_peaceful_apocalypse",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(main)/treetest/setup/[id]/_components/messages-tab.tsx
+++ b/src/app/(main)/treetest/setup/[id]/_components/messages-tab.tsx
@@ -394,6 +394,26 @@ export function MessagesTab({ data, onChange }: MessagesTabProps) {
                   placeholder="Text for the 'I'd find it here' button"
                 />
               </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="selectAsAnswer">
+                  Select Button
+                  <span className="ml-2 text-xs font-normal text-muted-foreground">
+                    Shown on parent nodes when non-leaf answers are allowed
+                  </span>
+                </Label>
+                <Input
+                  id="selectAsAnswer"
+                  value={data.customText.selectAsAnswer}
+                  onChange={(e) =>
+                    onChange({
+                      ...data,
+                      customText: { ...data.customText, selectAsAnswer: e.target.value },
+                    })
+                  }
+                  placeholder="Text for the 'Select' button on parent nodes"
+                />
+              </div>
             </div>
           </div>
 

--- a/src/app/(main)/treetest/setup/[id]/_components/setup-tabs.tsx
+++ b/src/app/(main)/treetest/setup/[id]/_components/setup-tabs.tsx
@@ -78,6 +78,7 @@ export default function SetupTabs({ params, showTour = false }: SetupTabsProps) 
       instructions: "",
       startTest: "",
       findItHere: "",
+      selectAsAnswer: "",
       startTask: "",
       confidenceQuestion: "",
       stronglyAgree: "",

--- a/src/app/(main)/treetest/setup/[id]/_components/tree-tab.tsx
+++ b/src/app/(main)/treetest/setup/[id]/_components/tree-tab.tsx
@@ -203,6 +203,7 @@ export function TreeTab({ data, onChange }: TreeTabProps) {
           <TreePreview
             nodes={data.tree.parsed}
             allowNonLeafAnswers={data.tasks.allowNonLeafAnswers ?? false}
+            selectAsAnswerText={data.customText.selectAsAnswer}
             onAllowNonLeafAnswersChange={(checked) =>
               onChange({ ...data, tasks: { ...data.tasks, allowNonLeafAnswers: checked } })
             }

--- a/src/components/tree-preview.tsx
+++ b/src/components/tree-preview.tsx
@@ -17,6 +17,8 @@ interface TreePreviewProps {
   /** Bound to the study's "Allow non-leaf nodes as answers" setting (tasks tab) */
   allowNonLeafAnswers?: boolean;
   onAllowNonLeafAnswersChange?: (checked: boolean) => void;
+  /** Custom label for the non-leaf "Select" button (messages tab) */
+  selectAsAnswerText?: string;
 }
 
 export function TreePreview({
@@ -24,6 +26,7 @@ export function TreePreview({
   className,
   allowNonLeafAnswers = false,
   onAllowNonLeafAnswersChange,
+  selectAsAnswerText,
 }: TreePreviewProps) {
   const [showParticipantView, setShowParticipantView] = useState(false);
   const [selectedLink, setSelectedLink] = useState<string>();
@@ -264,7 +267,7 @@ export function TreePreview({
                         handleSelectNonLeaf(currentPath);
                       }}
                     >
-                      Select
+                      {selectAsAnswerText || "Select"}
                     </Button>
                   </div>
                   <button

--- a/src/components/tree-test.tsx
+++ b/src/components/tree-test.tsx
@@ -512,7 +512,7 @@ export function TreeTestComponent({ config, initialTaskIndex = 0, onTaskChange }
                 allowNonLeafAnswers={config.allowNonLeafAnswers}
                 customText={{
                   findItHere: config.customText.findItHere,
-                  selectAsAnswer: "Select",
+                  selectAsAnswer: config.customText.selectAsAnswer,
                 }}
               />
             )}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -128,6 +128,7 @@ export const treeConfigs = sqliteTable("tree_configs", {
   instructionsText: text("instructions_text"),
   startTestText: text("start_test_text"),
   findItHereText: text("find_it_here_text"),
+  selectAsAnswerText: text("select_as_answer_text"),
   startTaskText: text("start_task_text"),
   confidenceQuestionText: text("confidence_question_text"),
   stronglyAgreeText: text("strongly_agree_text"),

--- a/src/lib/languages.ts
+++ b/src/lib/languages.ts
@@ -9,6 +9,7 @@ export interface TreeTestTranslation {
     instructions: string;
     startTest: string;
     findItHere: string;
+    selectAsAnswer: string;
     startTask: string;
     confidenceQuestion: string;
     stronglyAgree: string;
@@ -54,6 +55,7 @@ _This is not a test of your ability, there are no right or wrong answers._
 **That's it, let's get started!**`,
       startTest: "Start Test",
       findItHere: "I'd find it here",
+      selectAsAnswer: "Select",
       startTask: "Start Task {0}",
       confidenceQuestion: "How confident are you with your answer?",
       stronglyAgree: "Strongly Agree",
@@ -101,6 +103,7 @@ _Esto no es una prueba de su capacidad, no hay respuestas correctas o incorrecta
 **¡Eso es todo, comencemos!**`,
       startTest: "Comenzar Prueba",
       findItHere: "Lo encontraría aquí",
+      selectAsAnswer: "Seleccionar",
       startTask: "Comenzar Tarea {0}",
       confidenceQuestion: "¿Qué tan seguro está de su respuesta?",
       stronglyAgree: "Muy de Acuerdo",
@@ -148,6 +151,7 @@ _Ce n'est pas un test de vos capacités, il n'y a pas de bonnes ou de mauvaises 
 **C'est tout, commençons !**`,
       startTest: "Commencer le Test",
       findItHere: "Je le trouverais ici",
+      selectAsAnswer: "Sélectionner",
       startTask: "Commencer la Tâche {0}",
       confidenceQuestion: "À quel point êtes-vous confiant dans votre réponse ?",
       stronglyAgree: "Tout à fait d'Accord",
@@ -195,6 +199,7 @@ _Dies ist kein Test Ihrer Fähigkeiten, es gibt keine richtigen oder falschen An
 **Das ist alles, lassen Sie uns anfangen!**`,
       startTest: "Test Starten",
       findItHere: "Ich würde es hier finden",
+      selectAsAnswer: "Auswählen",
       startTask: "Aufgabe {0} Starten",
       confidenceQuestion: "Wie sicher sind Sie bei Ihrer Antwort?",
       stronglyAgree: "Stimme Voll Zu",
@@ -242,6 +247,7 @@ _Isto não é um teste da sua habilidade, não há respostas certas ou erradas._
 **Isso é tudo, vamos começar!**`,
       startTest: "Iniciar Teste",
       findItHere: "Eu encontraria aqui",
+      selectAsAnswer: "Selecionar",
       startTask: "Iniciar Tarefa {0}",
       confidenceQuestion: "Quão confiante você está na sua resposta?",
       stronglyAgree: "Concordo Totalmente",
@@ -298,6 +304,7 @@ _Di nuovo: non si tratta di un test delle Sue capacità, ma di un test sul nostr
 ![](instruction-img)`,
       startTest: "Cominciamo",
       findItHere: "Penso che sia qui",
+      selectAsAnswer: "Seleziona",
       startTask: "Andiamo alla domanda {0}",
       confidenceQuestion: "Quanto è sicuro/a della Sua risposta?",
       stronglyAgree: "Completamente sicuro/a",

--- a/src/lib/treetest/actions.ts
+++ b/src/lib/treetest/actions.ts
@@ -55,6 +55,7 @@ export async function createStudy(type: "tree_test" | "card_sort") {
           instructionsText: defaultCustomText.instructions,
           startTestText: defaultCustomText.startTest,
           findItHereText: defaultCustomText.findItHere,
+          selectAsAnswerText: defaultCustomText.selectAsAnswer,
           startTaskText: defaultCustomText.startTask,
           confidenceQuestionText: defaultCustomText.confidenceQuestion,
           stronglyAgreeText: defaultCustomText.stronglyAgree,
@@ -162,6 +163,7 @@ export async function saveStudyData(id: string, data: StudyFormData) {
             instructionsText: data.customText.instructions,
             startTestText: data.customText.startTest,
             findItHereText: data.customText.findItHere,
+            selectAsAnswerText: data.customText.selectAsAnswer,
             startTaskText: data.customText.startTask,
             confidenceQuestionText: data.customText.confidenceQuestion,
             stronglyAgreeText: data.customText.stronglyAgree,
@@ -187,6 +189,7 @@ export async function saveStudyData(id: string, data: StudyFormData) {
           instructionsText: data.customText.instructions,
           startTestText: data.customText.startTest,
           findItHereText: data.customText.findItHere,
+          selectAsAnswerText: data.customText.selectAsAnswer,
           startTaskText: data.customText.startTask,
           confidenceQuestionText: data.customText.confidenceQuestion,
           stronglyAgreeText: data.customText.stronglyAgree,
@@ -342,6 +345,7 @@ export async function loadStudyData(id: string) {
         instructions: config?.instructionsText || defaultCustomText.instructions,
         startTest: config?.startTestText || defaultCustomText.startTest,
         findItHere: config?.findItHereText || defaultCustomText.findItHere,
+        selectAsAnswer: config?.selectAsAnswerText || defaultCustomText.selectAsAnswer,
         startTask: ensureRequiredPlaceholders(
           config?.startTaskText || defaultCustomText.startTask,
           "startTask"
@@ -505,6 +509,7 @@ export async function loadTestConfig(id: string, preview: boolean = false, parti
         instructionsText: treeConfigs.instructionsText,
         startTestText: treeConfigs.startTestText,
         findItHereText: treeConfigs.findItHereText,
+        selectAsAnswerText: treeConfigs.selectAsAnswerText,
         startTaskText: treeConfigs.startTaskText,
         confidenceQuestionText: treeConfigs.confidenceQuestionText,
         stronglyAgreeText: treeConfigs.stronglyAgreeText,
@@ -572,6 +577,7 @@ export async function loadTestConfig(id: string, preview: boolean = false, parti
         instructions: config.instructionsText || defaultCustomText.instructions,
         startTest: config.startTestText || defaultCustomText.startTest,
         findItHere: config.findItHereText || defaultCustomText.findItHere,
+        selectAsAnswer: config.selectAsAnswerText || defaultCustomText.selectAsAnswer,
         startTask: ensureRequiredPlaceholders(
           config.startTaskText || defaultCustomText.startTask,
           "startTask"

--- a/src/lib/types/tree-test.ts
+++ b/src/lib/types/tree-test.ts
@@ -24,6 +24,7 @@ export interface StudyFormData {
     instructions: string;
     startTest: string;
     findItHere: string;
+    selectAsAnswer: string;
     startTask: string;
     confidenceQuestion: string;
     stronglyAgree: string;
@@ -69,6 +70,7 @@ export interface TreeTestConfig {
     instructions: string;
     startTest: string;
     findItHere: string;
+    selectAsAnswer: string;
     startTask: string;
     confidenceQuestion: string;
     stronglyAgree: string;


### PR DESCRIPTION
## Summary

Fixes #17 — the "Select" button shown on parent nodes (when "allow non-leaf answers" is enabled) was hardcoded in English at `tree-test.tsx`, so it stayed untranslated even when a study used a language preset, and it couldn't be customized in the test configuration.

This threads a new `selectAsAnswer` custom text through the existing custom-text pipeline, exactly like `findItHere`:

- **DB**: new nullable `select_as_answer_text` column on `tree_configs` (migration `0008`). Existing studies with a NULL value fall back to the English default via the same `||` fallback pattern used by every other custom text, so no backfill is needed.
- **Language presets** (`languages.ts`): `selectAsAnswer` added to all six presets — en "Select", es "Seleccionar", fr "Sélectionner", de "Auswählen", pt "Selecionar", it "Seleziona".
- **Participant UI** (`tree-test.tsx`): uses `config.customText.selectAsAnswer` instead of the hardcoded literal.
- **Setup UI** (`messages-tab.tsx`): new "Select Button" input in the Tree Navigation section; switching a language preset picks it up automatically since presets spread the full `customText` object.
- **Setup tree preview** (`tree-preview.tsx` / `tree-tab.tsx`): the participant-view mock now shows the configured label.
- **Server actions** (`actions.ts`): the create/save/load paths read and write the new column.

## Test plan

- [x] `tsc --noEmit`, `oxlint`, and `oxfmt --check` pass
- [x] Apply migration (`npm run db:migrate` / `db:push`)
- [x] Set language preset to German in setup → Messages tab shows "Auswählen" in the new Select Button field
- [x] Preview a study with non-leaf answers enabled → parent-node button shows the configured text
- [x] Existing study without the field saved → button still shows "Select"